### PR TITLE
fix unable renew cert

### DIFF
--- a/config/tls.go
+++ b/config/tls.go
@@ -70,13 +70,15 @@ func getCertificateFunc(managedCert bool, serverName, cert, key, keyType string)
 		KeySource: keyGenerator,
 	}
 
+	var magic *certmagic.Config
+
 	cache := certmagic.NewCache(certmagic.CacheOptions{
 		GetConfigForCert: func(certificate certmagic.Certificate) (c *certmagic.Config, err error) {
-			return &config, nil
+			return magic, nil
 		},
 	})
 
-	magic := certmagic.New(cache, config)
+	magic = certmagic.New(cache, config)
 
 	if managedCert {
 		err := magic.ManageAsync(context.Background(), []string{serverName})


### PR DESCRIPTION
10月 24 09:07:32 vultr.guest tls-shunt-proxy[999]: 1.7297608521964767e+09        error        maintenance        unable to get configuration to manage certificate; unable to renew        {"identifiers": ["****"], "error": "config returned for certificate [****] has nil cache; expected 0xc000321b00 (this one)"}